### PR TITLE
Set the `done` Promise of the autoMigrate() call

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ or run `node_modules/.bin/slc-migrate` directly.
 
 set `DEBUG=loopback:component:autoMigrate:*` env variable to show debug info.
 
-When it runs through `component-config.json`, it is attaching the `autoMigrate` promise at `app.get('loopback-component-auto-migrate')` that you can use to know when all migrations, data importing etc have finished. Also the `loopback-component-auto-migrate-status` will be set.
+When it runs through `component-config.json`, it is attaching the `autoMigrate` promise at `app.get('loopback-component-auto-migrate-done')` that you can use to know when all migrations, data importing etc have finished. 
 
-* loaded: autoMigrate loaded.
-* failed: autoMigrate failed.
-* done: autoMigrate successful.
+Also the `loopback-component-auto-migrate-status` will be set for convenience:
 
+  * 'loaded': autoMigrate loaded.
+  * 'failed': autoMigrate failed.
+  * 'done': autoMigrate successful.
 
 #### Manually use it:
 
@@ -68,6 +69,10 @@ autoMigrate(app, {models:['Role'], fixtures: 'yourDataFolder'}).then()
 ```
 
 ## History
+
+### v0.2.3
+
++ attaching done Promise at the app. 
 
 ### v0.2.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loopback-component-auto-migrate",
   "description": "migrate the database and import datas automatcally for the loopback application.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "Riceball LEE",
     "email": "snowyu.lee@gmail.com",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -13,7 +13,7 @@ module.exports = (app, options) ->
     autoMigrate = require './' + migration
     raiseError = (options and options.migration)
     app.set('loopback-component-auto-migrate-status', 'loaded')
-    app.set('loopback-component-auto-migrate', autoMigrate)
+
     autoMigrateDone = autoMigrate(app, options)
       .asCallback (err)->
         if err

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -14,14 +14,18 @@ module.exports = (app, options) ->
     raiseError = (options and options.migration)
     app.set('loopback-component-auto-migrate-status', 'loaded')
     app.set('loopback-component-auto-migrate', autoMigrate)
-    autoMigrate(app, options)
-    .asCallback (err)->
-      if err
-        app.set('loopback-component-auto-migrate-error', err)
-        app.set('loopback-component-auto-migrate-status', 'failed')
-        debug migration + ' failed: %O', err
-        throw err if raiseError
-      else
-        app.set('loopback-component-auto-migrate-status', 'done')
+    autoMigrateDone = autoMigrate(app, options)
+      .asCallback (err)->
+        if err
+          app.set('loopback-component-auto-migrate-error', err)
+          app.set('loopback-component-auto-migrate-status', 'failed')
+          debug migration + ' failed: %O', err
+          throw err if raiseError
+        else
+          app.set('loopback-component-auto-migrate-status', 'done')
+
+    app.set('loopback-component-auto-migrate-done', autoMigrateDone) # set the `done` promise of the `autoMigrate()` call
+
+    return autoMigrateDone
   else
     debug 'component not enabled'


### PR DESCRIPTION
Set the `done` Promise of autoMigrate() call at `loopback-component-auto-migrate-done`, as discussed https://github.com/snowyu/loopback-component-auto-migrate.js/pull/4#discussion_r106440526