### PR TITLE
Allowing "models" to be loaded directly from JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This loopback component enables you to migrate the database and import datas aut
     * "auto-update-data": update the tables, load datas from `fixtures` folder.
     * "auto-load-data": load datas from `fixtures` folder.
   - `models` *[array of String]*: the models to process. *defaults to the all models in the model-config.json*
+    * a JSON file location can be used instead of passing all list inside *component-config.json*: `"./test/models/model-list.json"`
   - `fixtures` *[String]*: the datas folder to import.
     * the file base name is the lowercase model name with dash seperated if any.
     * the file extension name is the data file format, the following format is supported:

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ This loopback component enables you to migrate the database and import datas aut
     * "auto-update" *defaults*: update the tables of the databse.
     * "auto-update-data": update the tables, load datas from `fixtures` folder.
     * "auto-load-data": load datas from `fixtures` folder.
-  - `models` *[array of String]*: the models to process. *defaults to the all models in the model-config.json*
-    * a JSON file location can be used instead of passing all list inside *component-config.json*: `"./test/models/model-list.json"`
+  - `models` *[array of String] | String*: the models to process. *defaults to the all models in the model-config.json*
+    * a config file location can be used instead of passing all list inside *component-config.json*. eg `"./test/models/model-list"` (you can use yaml, json or cson format by its extension name)
   - `fixtures` *[String]*: the datas folder to import.
     * the file base name is the lowercase model name with dash seperated if any.
     * the file extension name is the data file format, the following format is supported:

--- a/src/auto-load-data.coffee
+++ b/src/auto-load-data.coffee
@@ -1,15 +1,19 @@
-Promise     = require 'bluebird'
-isUndefined = require 'util-ex/lib/is/type/undefined'
+Promise        = require 'bluebird'
+isUndefined    = require 'util-ex/lib/is/type/undefined'
+isString       = require 'util-ex/lib/is/type/string'
 
-autoupdate  = require './auto-update'
-loadDataFrom= require './load-data-from'
-modelNames    = require './model-names'
+autoupdate     = require './auto-update'
+loadDataFrom   = require './load-data-from'
+modelNames     = require './model-names'
+loadModelsFrom = require './load-models-from'
 
 # import data
 module.exports = (aApp, aOptions) ->
   aDataFolder = aOptions and aOptions.fixtures
   return Promise.reject new TypeError 'Missing data folder' unless aDataFolder
   vModels = (aOptions and aOptions.models) || modelNames
+  # if models are coming from a JSON file, load the file and insert into vModels array
+  vModels = loadModelsFrom(aApp, vModels) if isString vModels
   vModels = vModels.map (model)->aApp.models[model]
   raiseError = aOptions?.raiseError
   vModels = Promise.map vModels, (model, index)->

--- a/src/auto-load-data.coffee
+++ b/src/auto-load-data.coffee
@@ -1,19 +1,13 @@
 Promise        = require 'bluebird'
 isUndefined    = require 'util-ex/lib/is/type/undefined'
-isString       = require 'util-ex/lib/is/type/string'
 
 autoupdate     = require './auto-update'
 loadDataFrom   = require './load-data-from'
-modelNames     = require './model-names'
-loadModelsFrom = require './load-models-from'
 
 # import data
-module.exports = (aApp, aOptions) ->
+module.exports = (aApp, aOptions, vModels) ->
   aDataFolder = aOptions and aOptions.fixtures
   return Promise.reject new TypeError 'Missing data folder' unless aDataFolder
-  vModels = (aOptions and aOptions.models) || modelNames
-  # if models are coming from a JSON file, load the file and insert into vModels array
-  vModels = loadModelsFrom(aApp, vModels) if isString vModels
   vModels = vModels.map (model)->aApp.models[model]
   raiseError = aOptions?.raiseError
   vModels = Promise.map vModels, (model, index)->

--- a/src/auto-migrate-data.coffee
+++ b/src/auto-migrate-data.coffee
@@ -1,11 +1,11 @@
-Promise     = require 'bluebird'
+Promise      = require 'bluebird'
 
-automigrate = require './auto-migrate'
-loadDataFrom= require './load-data-from'
+automigrate  = require './auto-migrate'
+loadDataFrom = require './load-data-from'
 
 # Migrate database and import data(if aDataFolder exists)
-module.exports = (aApp, aOptions) ->
-  result = automigrate(aApp, aOptions)
+module.exports = (aApp, aOptions, vModels) ->
+  result = automigrate(aApp, aOptions, vModels)
   aDataFolder = aOptions and aOptions.fixtures
   raiseError = aOptions?.raiseError
   if aDataFolder

--- a/src/auto-migrate.coffee
+++ b/src/auto-migrate.coffee
@@ -1,16 +1,20 @@
-Promise       = require 'bluebird'
-path          = require 'path'
-isFunction    = require 'util-ex/lib/is/type/function'
-isUndefined   = require 'util-ex/lib/is/type/undefined'
-debug         = require('debug')('loopback:component:autoMigrate:autoMigrate')
-appRoot       = require 'app-root-path'
-models        = require appRoot + '/server/model-config.json'
-modelNames    = require './model-names'
+Promise        = require 'bluebird'
+path           = require 'path'
+isFunction     = require 'util-ex/lib/is/type/function'
+isUndefined    = require 'util-ex/lib/is/type/undefined'
+isString       = require 'util-ex/lib/is/type/string'
+debug          = require('debug')('loopback:component:autoMigrate:autoMigrate')
+appRoot        = require 'app-root-path'
+models         = require appRoot + '/server/model-config.json'
+modelNames     = require './model-names'
+loadModelsFrom = require './load-models-from'
 
 # drop all tables and create all tables from models.
 module.exports = (app, options)->
   vModels = []
   vModelNames = (options and options.models) || modelNames
+  # if models are coming from a JSON file, load the file and insert into vModelNames array
+  vModelNames = loadModelsFrom(app, vModelNames) if isString vModelNames
   Promise.map vModelNames, (model)->
     ds = app.dataSources[models[model].dataSource]
     ds.setMaxListeners(0)

--- a/src/auto-migrate.coffee
+++ b/src/auto-migrate.coffee
@@ -2,19 +2,13 @@ Promise        = require 'bluebird'
 path           = require 'path'
 isFunction     = require 'util-ex/lib/is/type/function'
 isUndefined    = require 'util-ex/lib/is/type/undefined'
-isString       = require 'util-ex/lib/is/type/string'
 debug          = require('debug')('loopback:component:autoMigrate:autoMigrate')
 appRoot        = require 'app-root-path'
 models         = require appRoot + '/server/model-config.json'
-modelNames     = require './model-names'
-loadModelsFrom = require './load-models-from'
 
 # drop all tables and create all tables from models.
-module.exports = (app, options)->
+module.exports = (app, options, vModelNames)->
   vModels = []
-  vModelNames = (options and options.models) || modelNames
-  # if models are coming from a JSON file, load the file and insert into vModelNames array
-  vModelNames = loadModelsFrom(app, vModelNames) if isString vModelNames
   Promise.map vModelNames, (model)->
     ds = app.dataSources[models[model].dataSource]
     ds.setMaxListeners(0)

--- a/src/auto-update-data.coffee
+++ b/src/auto-update-data.coffee
@@ -1,7 +1,9 @@
-Promise       = require 'bluebird'
-autoupdate    = require './auto-update'
-loadDataFrom  = require './load-data-from'
-modelNames    = require './model-names'
+Promise        = require 'bluebird'
+isString       = require 'util-ex/lib/is/type/string'
+autoupdate     = require './auto-update'
+loadDataFrom   = require './load-data-from'
+modelNames     = require './model-names'
+loadModelsFrom = require './load-models-from'
 
 # update database and import data(if aDataFolder exists)
 module.exports = (aApp, aOptions) ->
@@ -11,6 +13,8 @@ module.exports = (aApp, aOptions) ->
   if aDataFolder
     result = result.then (models)->
       vModelNames = aOptions?.models || modelNames
+      # if models are coming from a JSON file, load the file and insert into vModelNames array
+      vModelNames = loadModelsFrom(aApp, vModelNames) if isString vModelNames
       models = Promise.map vModelNames, (model, index)->
         loadDataFrom(aApp, model, aDataFolder, raiseError)
       models

--- a/src/auto-update-data.coffee
+++ b/src/auto-update-data.coffee
@@ -1,20 +1,14 @@
 Promise        = require 'bluebird'
-isString       = require 'util-ex/lib/is/type/string'
 autoupdate     = require './auto-update'
 loadDataFrom   = require './load-data-from'
-modelNames     = require './model-names'
-loadModelsFrom = require './load-models-from'
 
 # update database and import data(if aDataFolder exists)
-module.exports = (aApp, aOptions) ->
+module.exports = (aApp, aOptions, vModelNames) ->
   aDataFolder = aOptions and aOptions.fixtures
   result = autoupdate(aApp, aOptions)
   raiseError = aOptions?.raiseError
   if aDataFolder
     result = result.then (models)->
-      vModelNames = aOptions?.models || modelNames
-      # if models are coming from a JSON file, load the file and insert into vModelNames array
-      vModelNames = loadModelsFrom(aApp, vModelNames) if isString vModelNames
       models = Promise.map vModelNames, (model, index)->
         loadDataFrom(aApp, model, aDataFolder, raiseError)
       models

--- a/src/auto-update.coffee
+++ b/src/auto-update.coffee
@@ -1,11 +1,14 @@
-Promise       = require "bluebird"
-path          = require 'path'
-isFunction    = require 'util-ex/lib/is/type/function'
-isUndefined   = require 'util-ex/lib/is/type/undefined'
-debug         = require('debug')('loopback:component:autoMigrate:autoUpdate')
-appRoot       = require 'app-root-path'
-models        = require appRoot + '/server/model-config.json'
-modelNames    = require './model-names'
+Promise        = require "bluebird"
+path           = require 'path'
+isFunction     = require 'util-ex/lib/is/type/function'
+isUndefined    = require 'util-ex/lib/is/type/undefined'
+isString       = require 'util-ex/lib/is/type/string'
+debug          = require('debug')('loopback:component:autoMigrate:autoUpdate')
+appRoot        = require 'app-root-path'
+models         = require appRoot + '/server/model-config.json'
+modelNames     = require './model-names'
+loadModelsFrom = require './load-models-from'
+
 
 isSyncModel = (ds, model)->
   new Promise (resolve, reject)->
@@ -24,6 +27,8 @@ isSyncModel = (ds, model)->
 module.exports = (app, options)->
   vModels = []
   vModelNames = (options and options.models) || modelNames
+  # if models are coming from a JSON file, load the file and insert into vModelNames array
+  vModelNames = loadModelsFrom(app, vModelNames) if isString vModelNames
   Promise.filter vModelNames, (model, index)->
     ds = app.dataSources[models[model].dataSource]
     isSyncModel(ds, model).then (actual)-> !actual

--- a/src/auto-update.coffee
+++ b/src/auto-update.coffee
@@ -2,13 +2,9 @@ Promise        = require "bluebird"
 path           = require 'path'
 isFunction     = require 'util-ex/lib/is/type/function'
 isUndefined    = require 'util-ex/lib/is/type/undefined'
-isString       = require 'util-ex/lib/is/type/string'
 debug          = require('debug')('loopback:component:autoMigrate:autoUpdate')
 appRoot        = require 'app-root-path'
 models         = require appRoot + '/server/model-config.json'
-modelNames     = require './model-names'
-loadModelsFrom = require './load-models-from'
-
 
 isSyncModel = (ds, model)->
   new Promise (resolve, reject)->
@@ -24,11 +20,8 @@ isSyncModel = (ds, model)->
           if err then reject(err) else resolve(actual)
 
 # drop all tables and create all tables from models.
-module.exports = (app, options)->
+module.exports = (app, options, vModelNames)->
   vModels = []
-  vModelNames = (options and options.models) || modelNames
-  # if models are coming from a JSON file, load the file and insert into vModelNames array
-  vModelNames = loadModelsFrom(app, vModelNames) if isString vModelNames
   Promise.filter vModelNames, (model, index)->
     ds = app.dataSources[models[model].dataSource]
     isSyncModel(ds, model).then (actual)-> !actual

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,10 @@
 'use strict'
 debug = require('debug')('loopback:component:autoMigrate:main')
 
+isString       = require 'util-ex/lib/is/type/string'
+modelNames     = require './model-names'
+loadModelsFrom = require './load-models-from'
+
 module.exports = (app, options) ->
   debug 'initializing component'
   loopback = app.loopback
@@ -14,7 +18,11 @@ module.exports = (app, options) ->
     raiseError = (options and options.migration)
     app.set('loopback-component-auto-migrate-status', 'loaded')
 
-    autoMigrateDone = autoMigrate(app, options)
+    vModels = (options and options.models) || modelNames
+    # if models are coming from a config file, load the file and insert into vModels array
+    vModels = loadModelsFrom(app, vModels) if isString vModels
+
+    autoMigrateDone = autoMigrate(app, options, vModels)
       .asCallback (err)->
         if err
           app.set('loopback-component-auto-migrate-error', err)

--- a/src/load-models-from.coffee
+++ b/src/load-models-from.coffee
@@ -1,0 +1,13 @@
+require './register-config-file-format'
+
+fs          = require 'fs'
+inflection  = require 'inflection'
+path        = require 'path'
+debug       = require('debug')('loopback:component:autoMigrate:loadModelsFrom')
+
+loadConfig  = require 'load-config-file'
+loadConfig  = loadConfig.load
+
+# load Models synchronously from a file
+module.exports = (app, folder) ->
+  return JSON.parse fs.readFileSync path.resolve(folder), 'utf8'

--- a/src/load-models-from.coffee
+++ b/src/load-models-from.coffee
@@ -1,13 +1,11 @@
 require './register-config-file-format'
 
-fs          = require 'fs'
-inflection  = require 'inflection'
 path        = require 'path'
 debug       = require('debug')('loopback:component:autoMigrate:loadModelsFrom')
 
 loadConfig  = require 'load-config-file'
-loadConfig  = loadConfig.load
+loadConfig  = loadConfig.loadSync
 
 # load Models synchronously from a file
 module.exports = (app, folder) ->
-  return JSON.parse fs.readFileSync path.resolve(folder), 'utf8'
+  return loadConfig path.resolve(folder), 'utf8'


### PR DESCRIPTION
Due to a work project needs, I added a way of loading the application models from a JSON file instead of passing the whole list inside _component-config.json_ file.

# Changes # 
1. Creation of _load-models-from.coffee_ file, which load the JSON synchronously.
2. Updates on migration and update files to call _load-models-from_ module.
3. Added new option on README.