### PR TITLE
skipMigration option added to skip migration for given model

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ autoMigrate(app, {models:['Role'], fixtures: 'yourDataFolder'}).then()
 
 ```
 
+#### Options:
+Migration can be disabled for the model if you specify `skipMigration` option in the `./server/model-config.json` file:
+```
+{
+  ...
+  "customModel": {
+      "dataSource": "datasource",
+      "public": true,
+      "options": {
+        "skipMigration": true
+      }
+  }
+  ...
+}
+```
 ## History
 
 ### v0.2.3

--- a/src/model-names.coffee
+++ b/src/model-names.coffee
@@ -6,4 +6,7 @@ models      = require appRoot + '/server/model-config.json'
 datasources = require appRoot + '/server/datasources.json'
 
 module.exports = Object.keys(models).filter (model)->
-    !(isUndefined(models[model].dataSource) or isUndefined(datasources[models[model].dataSource]))
+    !(isUndefined(models[model].dataSource) or
+      isUndefined(datasources[models[model].dataSource]) or
+      (models[model].options and models[model].options.skipMigration)
+    )


### PR DESCRIPTION
add skipMigration to model config so it can be disabled for models without PersistentModel and external datasources